### PR TITLE
Add a SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ This is a template repository. Below is a checklist of things you should do to u
 - [ ] Install the `pre-commit` hooks.
 - [ ] Update the `LICENSE` file to your desired license and set the year.
 - [ ] Replace "ENTER_YOUR_EMAIL_ADDRESS" in `CODE_OF_CONDUCT.md`
+- [ ] Replace "ENTER_YOUR_EMAIL_ADDRESS" in `SECURITY.md` and update the supported versions or, if not relevant, delete this file.
 - [ ] Remove the placeholder src and test files, these are there merely to show how the CI works.
 - [ ] Update `pyproject.toml`
 - [ ] Update the name of `src/APP_NAME`
 - [ ] Grant third-party app permissions (e.g. Codecov) [here](https://github.com/organizations/cmi-dair/settings/installations), if necessary.
 - [ ] Either generate a `CODECOV_TOKEN` secret [here](https://github.com/cmi-dair/flowdump/blob/main/.github/workflows/python_tests.yaml) (if its a private repository) or remove the line `token: ${{ secrets.CODECOV_TOKEN }}`
-
 
 # Project name
 
@@ -21,7 +21,6 @@ This is a template repository. Below is a checklist of things you should do to u
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![L-GPL License](https://img.shields.io/badge/license-L--GPL-blue.svg)](LICENSE)
 [![pages](https://img.shields.io/badge/api-docs-blue)](https://cmi-dair.github.io/template-python-repository)
-
 
 What problem does this tool solve?
 
@@ -47,7 +46,7 @@ pip install git+https://github.com/cmi-dair/template_python_repository
 
 ## Quick start
 
-Short tutorial, maybe with a 
+Short tutorial, maybe with a
 
 ```Python
 import template_python_repository

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security
+
+Child Mind Institute values the security of our users, data, and servers. We take the security of our systems seriously and encourage users to report any suspected security vulnerabilities promptly.
+
+## Supported Versions
+
+MODIFY:
+
+Note which version(s) will receive security updates. For example:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.0.x   | :white_check_mark: |
+| 0.9.x   | :x:                |
+
+## Reporting Vulnerabilities
+
+To report security vulnerabilities, please do NOT use our issues page. Instead, kindly email us at ENTER_YOUR_EMAIL_ADDRESS. Please refrain from using other communication channels.
+
+For non-security-related issues, we welcome your input and feedback on our issues page. Feel free to share your ideas and suggestions to help us improve our services.


### PR DESCRIPTION
This PR adds a security policy which informs users on how to inform us of security vulnerabilities in our applications. For an example usage, see the side bar of https://github.com/cmi-dair/cross-species-mapper/ . 

Instructions have been added to the README.md to either modify SECURITY.md, or delete it if it's not relevant.