### PR TITLE
Require poetry 1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ pytest-cov = "^4.1.0"
 docs = ["pdoc"]
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Was getting
```
RuntimeError

  The Poetry configuration is invalid:
    - Additional properties are not allowed ('group' was unexpected)
```
in an old env.

For reference [poetry is at 1.5](https://pypi.org/project/poetry/) now so this is still very lenient.

https://stackoverflow.com/questions/73876790/poetry-configuration-is-invalid-additional-properties-are-not-allowed-group