### PR TITLE
Move pdoc to a `docs` dependency group

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -227,7 +227,7 @@ requirements-deprecated-finder = ["pip-api", "pipreqs"]
 name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
@@ -244,7 +244,7 @@ i18n = ["Babel (>=2.7)"]
 name = "markupsafe"
 version = "2.1.3"
 description = "Safely add untrusted strings to HTML/XML markup."
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa"},
@@ -395,7 +395,7 @@ files = [
 name = "pdoc"
 version = "14.0.0"
 description = "API Documentation for Python Projects"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "pdoc-14.0.0-py3-none-any.whl", hash = "sha256:4514041ff5da33f1adbc700002a661600fc13a9adadef317bc6ae8be9e61154b"},
@@ -462,7 +462,7 @@ virtualenv = ">=20.10.0"
 name = "pygments"
 version = "2.15.1"
 description = "Pygments is a syntax highlighting package written in Python."
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "Pygments-2.15.1-py3-none-any.whl", hash = "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"},
@@ -607,9 +607,9 @@ docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.3.1)", "pytest-env (>=0.8.1)", "pytest-freezer (>=0.4.6)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=67.8)", "time-machine (>=2.9)"]
 
 [extras]
-docs = ["pdoc"]
+docs = []
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "2c61901c37c812b05a557df764bc3d0e05d986b075c8defc518164a92c335342"
+content-hash = "c72b017f9500b036c719d4d550b70c48739e65cee29ab1d110198ac127e42d4d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ packages = [{include = "APP_NAME", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-pdoc = { version = "^14.0.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.2"
@@ -18,6 +17,9 @@ black = "^23.3.0"
 isort = "^5.12.0"
 pre-commit = "^3.3.3"
 pytest-cov = "^4.1.0"
+
+[tool.poetry.group.docs.dependencies]
+pdoc = "^14.0.0"
 
 [tool.poetry.extras]
 docs = ["pdoc"]


### PR DESCRIPTION
Currently, `pdoc` is part of the main dependencies (albeit optional). This PR moves it to its own `docs` dependency. This is already implied as the intention by the [workflow](https://github.com/cmi-dair/template-python-repository/blob/main/.github/workflows/docs.yml) which tries to install a (currently non-existent) `docs` group. 