### PR TITLE
Docs workflow auto detect module name

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,8 @@ jobs:
           poetry install -E docs
       - name: Build docs
         run: |
-          poetry run pdoc src/APP_NAME -o docs_build -t docs/pdoc-theme --docformat google
+          APP_MODULE_NAME=$(ls src -U | head -1)  # Get the first module name in the src directory
+          poetry run pdoc src/"$APP_MODULE_NAME" -o docs_build -t docs/pdoc-theme --docformat google
           touch docs_build/.nojekyll
       - uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is a template repository. Below is a checklist of things you should do to u
 - [ ] Update the name of `src/APP_NAME`
 - [ ] Grant third-party app permissions (e.g. Codecov) [here](https://github.com/organizations/cmi-dair/settings/installations), if necessary.
 - [ ] Either generate a `CODECOV_TOKEN` secret [here](https://github.com/cmi-dair/flowdump/blob/main/.github/workflows/python_tests.yaml) (if its a private repository) or remove the line `token: ${{ secrets.CODECOV_TOKEN }}`
+- [ ] API docs website: After the first successful build, go to the `Settings` tab of your repository, scroll down to the `GitHub Pages` section, and select `gh-pages` as the source. This will generate a link to your API docs.
 
 
 # Project name


### PR DESCRIPTION
Docs workflow will now just take the first folder within the `src/` folder as its target.

- Saves one string replacement when using this template or changing module name later on

Potentially solves https://github.com/cmi-dair/template-python-repository/issues/18 because no user action is required anymore