### PR TITLE
Switch to dashes in repo (badge) links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ This is a template repository. Below is a checklist of things you should do to u
 
 # Project name
 
-[![Build](https://github.com/cmi-dair/template_python_repository/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/cmi-dair/template_python_repository/actions/workflows/test.yaml?query=branch%3Amain)
-[![codecov](https://codecov.io/gh/cmi-dair/template_python_repository/branch/main/graph/badge.svg?token=22HWWFWPW5)](https://codecov.io/gh/cmi-dair/template_python_repository)
+[![Build](https://github.com/cmi-dair/template-python-repository/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/cmi-dair/template-python-repository/actions/workflows/test.yaml?query=branch%3Amain)
+[![codecov](https://codecov.io/gh/cmi-dair/template-python-repository/branch/main/graph/badge.svg?token=22HWWFWPW5)](https://codecov.io/gh/cmi-dair/template-python-repository)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![L-GPL License](https://img.shields.io/badge/license-L--GPL-blue.svg)](LICENSE)
 [![pages](https://img.shields.io/badge/api-docs-blue)](https://cmi-dair.github.io/template-python-repository)
@@ -36,13 +36,13 @@ What problem does this tool solve?
 Install this package via :
 
 ```sh
-pip install template_python_repository
+pip install template-python-repository
 ```
 
 Or get the newest development version via:
 
 ```sh
-pip install git+https://github.com/cmi-dair/template_python_repository
+pip install git+https://github.com/cmi-dair/template-python-repository
 ```
 
 ## Quick start
@@ -50,9 +50,9 @@ pip install git+https://github.com/cmi-dair/template_python_repository
 Short tutorial, maybe with a 
 
 ```Python
-import template_python_repository
+import template-python-repository
 
-template_python_repository.short_example()
+template-python-repository.short_example()
 ```
 
 ## Links or References


### PR DESCRIPTION
Consistent naming helps with `template-python-repository` -> `my-own-repo-name`

Before one badge used dashes the others underscore from back when we renamed the repo