### PR TITLE
Setup template fix #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,12 @@
 
 This is a template repository. Below is a checklist of things you should do to use it:
 
-- [ ] Rewrite this `README` file, updating the badges as needed.
-- [ ] Update the pre-commit versions in `.pre-commit-config.yaml`.
-- [ ] Install the `pre-commit` hooks.
+- [ ] Run `setup_template.py` to set up the repository.
+- [ ] Rewrite this `README` file.
+- [ ] Update the pre-commit versions in `.pre-commit-config.yaml` and install the `pre-commit` hooks..
 - [ ] Update the `LICENSE` file to your desired license and set the year.
-- [ ] Replace "ENTER_YOUR_EMAIL_ADDRESS" in `CODE_OF_CONDUCT.md`
-- [ ] Replace "ENTER_YOUR_EMAIL_ADDRESS" in `SECURITY.md` and update the supported versions or, if not relevant, delete this file.
+- [ ] Update the supported versions in `SECURITY.md` or, if not relevant, delete this file.
 - [ ] Remove the placeholder src and test files, these are there merely to show how the CI works.
-- [ ] Update `pyproject.toml`
-- [ ] Update the name of `src/APP_NAME`
 - [ ] Grant third-party app permissions (e.g. Codecov) [here](https://github.com/organizations/cmi-dair/settings/installations), if necessary.
 - [ ] Either generate a `CODECOV_TOKEN` secret [here](https://github.com/cmi-dair/flowdump/blob/main/.github/workflows/python_tests.yaml) (if its a private repository) or remove the line `token: ${{ secrets.CODECOV_TOKEN }}`
 - [ ] API docs website: After the first successful build, go to the `Settings` tab of your repository, scroll down to the `GitHub Pages` section, and select `gh-pages` as the source. This will generate a link to your API docs.

--- a/setup_template.py
+++ b/setup_template.py
@@ -26,10 +26,10 @@ def main():
 
     # Print the data
     print(
-        f"Using the following values:"
-        f"\tRepository name: {repo_name}"
-        f"\tModule name: {module_name}"
-        f"\tAuthor: {username} <{email}>"
+        f"Using the following values:\n"
+        f"\tRepository name: {repo_name}\n"
+        f"\tModule name: {module_name}\n"
+        f"\tAuthor: {username} <{email}>\n"
         f"\tDescription: {description}"
     )
     input("Press enter to continue...")

--- a/setup_template.py
+++ b/setup_template.py
@@ -6,6 +6,7 @@ import pathlib as pl
 
 def main():
     # Collect some data
+    git_uncommitted_changes = os.popen("git status -s").read().strip() != ""
     git_username = os.popen("git config user.name").read().strip()
     git_email = os.popen("git config user.email").read().strip()
     git_repo_name = (
@@ -13,6 +14,9 @@ def main():
     )
 
     # Ask for some data
+    if git_uncommitted_changes:
+        print("You have uncommitted changes. Please commit or stash them first.")
+        exit(1)
     repo_name = (
         input(f"Enter the name of the repository [{git_repo_name}]: ") or git_repo_name
     )
@@ -27,10 +31,10 @@ def main():
     # Print the data
     print(
         f"Using the following values:\n"
-        f"\tRepository name: {repo_name}\n"
-        f"\tModule name: {module_name}\n"
-        f"\tAuthor: {username} <{email}>\n"
-        f"\tDescription: {description}"
+        f"\tRepository name: '{repo_name}'\n"
+        f"\tModule name: '{module_name}'\n"
+        f"\tAuthor: '{username} <{email}'>\n"
+        f"\tDescription: '{description}'"
     )
     input("Press enter to continue...")
 
@@ -41,7 +45,6 @@ def main():
             and not file.name == "setup_template.py"
             and file.suffix in [".py", ".md", ".yml", ".yaml", ".toml", ".txt"]
         ):
-            print(f"Processing {file}")
             with open(file, "r") as f:
                 content = f.read()
 

--- a/setup_template.py
+++ b/setup_template.py
@@ -10,11 +10,16 @@ def main():
     dir_repo = file_self.parent
 
     # Collect some data
-    git_uncommitted_changes = os.popen(f"git -C {dir_repo} status -s").read().strip() != ""
+    git_uncommitted_changes = (
+        os.popen(f"git -C {dir_repo} status -s").read().strip() != ""
+    )
     git_username = os.popen(f"git -C {dir_repo} config user.name").read().strip()
     git_email = os.popen(f"git -C {dir_repo} config user.email").read().strip()
     git_repo_name = (
-        os.popen(f"git -C {dir_repo} remote get-url origin").read().split("/")[-1].split(".")[0]
+        os.popen(f"git -C {dir_repo} remote get-url origin")
+        .read()
+        .split("/")[-1]
+        .split(".")[0]
     )
 
     # Ask for some data
@@ -69,7 +74,7 @@ def main():
                 with open(file, "w") as f:
                     f.write(content)
 
-    dir_module = (dir_repo / "src" / "APP_NAME")
+    dir_module = dir_repo / "src" / "APP_NAME"
     if dir_module.exists():
         dir_module.rename(dir_module.parent / module_name)
 

--- a/setup_template.py
+++ b/setup_template.py
@@ -74,7 +74,7 @@ def main():
         dir_module.rename(dir_module.parent / module_name)
 
     # Remove this file
-    print("Removing setup_template.py")
+    print(f"Removing {file_self.name}")
     pl.Path(__file__).unlink(missing_ok=True)
 
 

--- a/setup_template.py
+++ b/setup_template.py
@@ -73,7 +73,7 @@ def main():
 
     # Remove this file
     print("Removing setup_template.py")
-    pl.Path("setup_template.py").unlink(missing_ok=True)
+    pl.Path(__file__).unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/setup_template.py
+++ b/setup_template.py
@@ -5,6 +5,9 @@ import pathlib as pl
 
 
 def main():
+    # Ensure working dir == repo root
+    os.chdir(pl.Path(__file__).parent)
+
     # Collect some data
     git_uncommitted_changes = os.popen("git status -s").read().strip() != ""
     git_username = os.popen("git config user.name").read().strip()
@@ -42,7 +45,7 @@ def main():
     for file in pl.Path(".").glob("**/*"):
         if (
             file.is_file()
-            and not file.name == "setup_template.py"
+            and not file.name == pl.Path(__file__).name
             and file.suffix in [".py", ".md", ".yml", ".yaml", ".toml", ".txt"]
         ):
             with open(file, "r") as f:
@@ -65,8 +68,8 @@ def main():
                 with open(file, "w") as f:
                     f.write(content)
 
-    if pl.Path(f"src/APP_NAME").exists():
-        pl.Path(f"src/APP_NAME").rename(f"src/{module_name}")
+    if pl.Path("src/APP_NAME").exists():
+        pl.Path("src/APP_NAME").rename(f"src/{module_name}")
 
     # Remove this file
     print("Removing setup_template.py")

--- a/setup_template.py
+++ b/setup_template.py
@@ -1,0 +1,71 @@
+#!/usr/bin python3
+
+import os
+import pathlib as pl
+
+
+def main():
+    # Collect some data
+    git_username = os.popen("git config user.name").read().strip()
+    git_email = os.popen("git config user.email").read().strip()
+    git_repo_name = (
+        os.popen("git remote get-url origin").read().split("/")[-1].split(".")[0]
+    )
+
+    # Ask for some data
+    repo_name = (
+        input(f"Enter the name of the repository [{git_repo_name}]: ") or git_repo_name
+    )
+    module_name = input(f"Enter the name of the module [{repo_name}]: ") or repo_name
+    username = input(f"Enter your username [{git_username}]: ") or git_username
+    email = input(f"Enter your email [{git_email}]: ") or git_email
+    description = (
+        input("Enter a short description of the project: ")
+        or "A beautiful description."
+    )
+
+    # Print the data
+    print(
+        f"Using the following values:"
+        f"\tRepository name: {repo_name}"
+        f"\tModule name: {module_name}"
+        f"\tAuthor: {username} <{email}>"
+        f"\tDescription: {description}"
+    )
+    input("Press enter to continue...")
+
+    # Replace the template values
+    for file in pl.Path(".").glob("**/*"):
+        if (
+            file.is_file()
+            and not file.name == "setup_template.py"
+            and file.suffix in [".py", ".md", ".yml", ".yaml", ".toml", ".txt"]
+        ):
+            print(f"Processing {file}")
+            with open(file, "r") as f:
+                content = f.read()
+
+            content_before = content
+            content = content.replace("template-python-repository", repo_name)
+            content = content.replace("APP_NAME", module_name)
+            content = content.replace("app-name", module_name)
+            content = content.replace("A beautiful description.", description)
+            content = content.replace("reinder.vosdewael@childmind.org", email)
+            content = content.replace("ENTER_YOUR_EMAIL_ADDRESS", email)
+            content = content.replace("Reinder Vos de Wael", username)
+
+            if not content == content_before:
+                print(f"Updating {file}")
+                with open(file, "w") as f:
+                    f.write(content)
+
+    if pl.Path(f"src/APP_NAME").exists():
+        pl.Path(f"src/APP_NAME").rename(f"src/{module_name}")
+
+    # Remove this file
+    print("Removing setup_template.py")
+    pl.Path("setup_template.py").unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup_template.py
+++ b/setup_template.py
@@ -6,14 +6,15 @@ import pathlib as pl
 
 def main():
     # Ensure working dir == repo root
-    os.chdir(pl.Path(__file__).parent)
+    file_self = pl.Path(__file__)
+    dir_repo = file_self.parent
 
     # Collect some data
-    git_uncommitted_changes = os.popen("git status -s").read().strip() != ""
-    git_username = os.popen("git config user.name").read().strip()
-    git_email = os.popen("git config user.email").read().strip()
+    git_uncommitted_changes = os.popen(f"git -C {dir_repo} status -s").read().strip() != ""
+    git_username = os.popen("git -C {dir_repo} config user.name").read().strip()
+    git_email = os.popen("git -C {dir_repo} config user.email").read().strip()
     git_repo_name = (
-        os.popen("git remote get-url origin").read().split("/")[-1].split(".")[0]
+        os.popen("git -C {dir_repo} remote get-url origin").read().split("/")[-1].split(".")[0]
     )
 
     # Ask for some data
@@ -42,10 +43,10 @@ def main():
     input("Press enter to continue...")
 
     # Replace the template values
-    for file in pl.Path(".").glob("**/*"):
+    for file in pl.Path(dir_repo).glob("**/*"):
         if (
             file.is_file()
-            and not file.name == pl.Path(__file__).name
+            and not file.name == file_self.name
             and file.suffix in [".py", ".md", ".yml", ".yaml", ".toml", ".txt"]
         ):
             with open(file, "r") as f:
@@ -68,8 +69,9 @@ def main():
                 with open(file, "w") as f:
                     f.write(content)
 
-    if pl.Path("src/APP_NAME").exists():
-        pl.Path("src/APP_NAME").rename(f"src/{module_name}")
+    dir_module = (dir_repo / "src" / "APP_NAME")
+    if dir_module.exists():
+        dir_module.rename(dir_module.parent / module_name)
 
     # Remove this file
     print("Removing setup_template.py")

--- a/setup_template.py
+++ b/setup_template.py
@@ -11,10 +11,10 @@ def main():
 
     # Collect some data
     git_uncommitted_changes = os.popen(f"git -C {dir_repo} status -s").read().strip() != ""
-    git_username = os.popen("git -C {dir_repo} config user.name").read().strip()
-    git_email = os.popen("git -C {dir_repo} config user.email").read().strip()
+    git_username = os.popen(f"git -C {dir_repo} config user.name").read().strip()
+    git_email = os.popen(f"git -C {dir_repo} config user.email").read().strip()
     git_repo_name = (
-        os.popen("git -C {dir_repo} remote get-url origin").read().split("/")[-1].split(".")[0]
+        os.popen(f"git -C {dir_repo} remote get-url origin").read().split("/")[-1].split(".")[0]
     )
 
     # Ask for some data

--- a/setup_template.py
+++ b/setup_template.py
@@ -49,6 +49,9 @@ def main():
                 content = f.read()
 
             content_before = content
+            content = content.replace(
+                "- [ ] Run `setup_template.py`", "- [x] Run `setup_template.py`"
+            )
             content = content.replace("template-python-repository", repo_name)
             content = content.replace("APP_NAME", module_name)
             content = content.replace("app-name", module_name)

--- a/setup_template.py
+++ b/setup_template.py
@@ -65,7 +65,7 @@ def main():
             content = content.replace("Reinder Vos de Wael", username)
 
             if not content == content_before:
-                print(f"Updating {file}")
+                print(f"Updating {file.relative_to(dir_repo)}")
                 with open(file, "w") as f:
                     f.write(content)
 


### PR DESCRIPTION
Adds a setup_template.py script that performs many of the setup steps automatically.

This small CLI (with hopefully smart defaults pulled from the local git repo):

![image](https://github.com/cmi-dair/template-python-repository/assets/33600480/6a034527-693b-4655-b52a-fea1d3fbb1e5)

Leads to:

![image](https://github.com/cmi-dair/template-python-repository/assets/33600480/1cde8e64-936e-422d-810f-d1d2c1485188)

To prevent data loss the script will only run if the user has no uncommited changes:

![image](https://github.com/cmi-dair/template-python-repository/assets/33600480/6e47ec33-c1ed-484c-8040-c6b3eebc4fbd)
