### PR TITLE
Remove github coverage comment

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Pytest coverage comment
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        if: github.event_name == 'pull_request' && ${{ env.CODECOV_TOKEN }} == ''
+        if: github.event_name == 'pull_request' && ${{ env.CODECOV_TOKEN == '' }}
         uses: MishaKav/pytest-coverage-comment@main
         with:
           pytest-coverage-path: ./pytest-coverage.txt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,9 @@ jobs:
       - name: Run tests
         run: poetry run pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov-report=xml:coverage.xml --cov=src tests | tee pytest-coverage.txt
       - name: Pytest coverage comment
-        if: github.event_name == 'pull_request' && ${{ secrets.CODECOV_TOKEN }} == ''
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: github.event_name == 'pull_request' && ${{ env.CODECOV_TOKEN }} == ''
         uses: MishaKav/pytest-coverage-comment@main
         with:
           pytest-coverage-path: ./pytest-coverage.txt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,13 +22,12 @@ jobs:
           python -m pip install poetry
           poetry install
       - name: Run tests
-        run: poetry run pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov-report=xml:coverage.xml --cov=src tests | tee pytest-coverage.txt
-      - name: Pytest coverage comment
-        if: github.event_name == 'pull_request'
-        uses: MishaKav/pytest-coverage-comment@main
-        with:
-          pytest-coverage-path: ./pytest-coverage.txt
-          junitxml-path: ./pytest.xml
+        run: poetry run pytest \
+          --junitxml=pytest.xml \
+          --cov-report=term-missing:skip-covered \
+          --cov-report=xml:coverage.xml \
+          --cov=src tests | \
+          tee pytest-coverage.txt
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,12 +22,7 @@ jobs:
           python -m pip install poetry
           poetry install
       - name: Run tests
-        run: poetry run pytest \
-          --junitxml=pytest.xml \
-          --cov-report=term-missing:skip-covered \
-          --cov-report=xml:coverage.xml \
-          --cov=src tests | \
-          tee pytest-coverage.txt
+        run: poetry run pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov-report=xml:coverage.xml --cov=src tests | tee pytest-coverage.txt
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,12 @@ jobs:
           poetry install
       - name: Run tests
         run: poetry run pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov-report=xml:coverage.xml --cov=src tests | tee pytest-coverage.txt
+      - name: Pytest coverage comment
+        if: github.event_name == 'pull_request' && ${{ secrets.CODECOV_TOKEN }} == ''
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-coverage-path: ./pytest-coverage.txt
+          junitxml-path: ./pytest.xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
- Resolves #32 

Currently, we're using two different services for a code coverage comment (CodeCov, GitHub). As CodeCov is more feature rich, I've removed the Github comment in this PR. 