### PR TITLE
Fix unit test failures not detected.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,21 +8,59 @@ on:
 
 jobs:
   unit:
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install poetry
+        run: pipx install poetry
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+          cache: poetry
       - name: Install dependencies
         run: |
-          python -m pip install poetry
           poetry install
       - name: Run tests
-        run: poetry run pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov-report=xml:coverage.xml --cov=src tests | tee pytest-coverage.txt
+        id: run-tests
+        continue-on-error: true
+        run: >
+          poetry run pytest \
+            --junitxml=pytest.xml \
+            --cov-report=term-missing:skip-covered \
+            --cov-report=xml:coverage.xml \
+            --cov=src tests \
+            > ./pytest-coverage.txt;
+          cat ./pytest-coverage.txt;
+      - name: Upload pytest coverage artifacts.
+        uses: actions/upload-artifact@v2
+        with:
+          name: pytest-coverage
+          path: ./pytest-coverage.txt
+      - name: Upload pytest junitxml artifacts.
+        uses: actions/upload-artifact@v2
+        with:
+          name: pytest-junitxml
+          path: pytest.xml
+      - name: Checking testing success.
+        if: steps.run-tests.outcome != 'success'
+        run: exit 1;
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: unit
+    if: success() || failure()
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Get pytest artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: pytest-coverage
+      - name: Get pytest junitxml artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: pytest-junitxml
       - name: Pytest coverage comment
         if: github.event_name == 'pull_request'
         uses: MishaKav/pytest-coverage-comment@main
@@ -30,6 +68,7 @@ jobs:
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./pytest.xml
       - name: Upload coverage to Codecov
+        if: success() || failure()
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,11 +24,11 @@ jobs:
         id: run-tests
         continue-on-error: true
         run: >
-          poetry run pytest \
-            --junitxml=pytest.xml \
-            --cov-report=term-missing:skip-covered \
-            --cov-report=xml:coverage.xml \
-            --cov=src tests \
+          poetry run pytest
+            --junitxml=pytest.xml
+            --cov-report=term-missing:skip-covered
+            --cov-report=xml:coverage.xml
+            --cov=src tests
             > ./pytest-coverage.txt;
           cat ./pytest-coverage.txt;
       - name: Upload pytest coverage artifacts.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,11 +24,11 @@ jobs:
         id: run-tests
         continue-on-error: true
         run: >
-          poetry run pytest
-            --junitxml=pytest.xml
-            --cov-report=term-missing:skip-covered
-            --cov-report=xml:coverage.xml
-            --cov=src tests
+          poetry run pytest \
+            --junitxml=pytest.xml \
+            --cov-report=term-missing:skip-covered \
+            --cov-report=xml:coverage.xml \
+            --cov=src tests \
             > ./pytest-coverage.txt;
           cat ./pytest-coverage.txt;
       - name: Upload pytest coverage artifacts.


### PR DESCRIPTION
Failing unit tests were not resulting in a failing CI due to the output of pytest being piped. This PR resolves that, and also adds caching of poetry dependencies for faster CI :D. 

The following changes were made:
- Poetry install is now cached.
- The unit test job will continue if it has a non-zero exit status.
- Coverage has been moved into a separate job, which is dependent on the unit test job. 
