### PR TITLE
Add development task issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/development_task.yaml
+++ b/.github/ISSUE_TEMPLATE/development_task.yaml
@@ -3,7 +3,7 @@ description: "This is a template for a development task"
 # If you want to enable automatic linking to projects,
 # uncomment the following line and replace the project ID
 # with the ID of your project.
-# projects: []"cmi-dair/1"]
+# projects: ["cmi-dair/1"]
 title: "Task: "
 labels: ["task"]
 body:

--- a/.github/ISSUE_TEMPLATE/development_task.yaml
+++ b/.github/ISSUE_TEMPLATE/development_task.yaml
@@ -3,7 +3,7 @@ description: "This is a template for a development task"
 # If you want to enable automatic linking to projects,
 # uncomment the following line and replace the project ID
 # with the ID of your project.
-# projects: "cmi-dair/1"
+# projects: []"cmi-dair/1"]
 title: "Task: "
 labels: ["task"]
 body:

--- a/.github/ISSUE_TEMPLATE/development_task.yaml
+++ b/.github/ISSUE_TEMPLATE/development_task.yaml
@@ -1,0 +1,32 @@
+name: "Development Task"
+description: "This is a template for a development task"
+# If you want to enable automatic linking to projects,
+# uncomment the following line and replace the project ID
+# with the ID of your project.
+# projects: "cmi-dair/1"
+title: "Task: "
+labels: ["task"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: "What is the task about? Why is it needed? What is the current state, if any?"
+      placeholder: "Describe the task here"
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: "What are the concrete (sub-)tasks that need to be performed?"
+      placeholder: "Describe the tasks here."
+      value: "- [ ] Task 1"
+    validations:
+      required: true
+  - type: textarea
+    id: freeform-notes
+    attributes:
+      label: "Freeform Notes"
+      description: "Add any additional notes here."
+      placeholder: "Add notes here."


### PR DESCRIPTION
- Resolves #37 .

This PR adds an issue template for development tasks. It contains a description, task list, and freeform notes. Issues created through this template are automatically assigned the "task" label (if present in the repository, has been set as a default label in the organization). These tasks can also be automatically linked to existing projects by uncommenting the [project line in the YAML file](https://github.com/cmi-dair/template-python-repository/compare/feature/task-issue?expand=1#diff-f2b0ba60240157dde9f99af2e09aed31e5abff4164b3af54a1320b5f60b83dfbR6). 

I slightly changed the format as proposed in #37, as I feel the Task list and DoD set-up proposed there may have too much overlap. 

For an example of the form see: https://github.com/ReinderVosDeWael/issue-template-playground/issues/new?assignees=&labels=task&projects=&template=development_task.yaml&title=Task%3A+

For an example of the created issue see: https://github.com/ReinderVosDeWael/issue-template-playground/issues/1

 