### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# template-python-repository pull request guidelines
+
+Pull requests are always welcome, and we appreciate any help you give. Note that a code of conduct applies to all spaces managed by the template-python-repository project, including issues and pull requests. Please see the [Code of Conduct](CODE_OF_CONDUCT.md) for details.
+
+When submitting a pull request, we ask you to check the following:
+
+1. **Unit tests**, **documentation**, and **code style** are in order.
+   See the Continuous Integration for up to date information on the current code style, tests, and any other requirements.
+
+   It is also OK to submit work in progress if you're unsure of what this exactly means, in which case you'll likely be asked to make some further changes.
+
+2. The contributed code will be **licensed under the same [license](LICENSE) as the rest of the repository**, If you did not write the code yourself, you must ensure the existing license is compatible and include the license information in the contributed files, or obtain permission from the original author to relicense the contributed code.


### PR DESCRIPTION
- Resolves #34 

This PR adds a basic contributing guide to the repository. The repository name will be automatically replaced by the setup script. 