### PR TITLE
Refactor test workflow to fail gracefully

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,53 +22,15 @@ jobs:
         poetry install
     - name: Run tests
       id: run-tests
-      continue-on-error: true
       run: >
         poetry run pytest \
           --junitxml=pytest.xml \
           --cov-report=term-missing:skip-covered \
           --cov-report=xml:coverage.xml \
           --cov=src tests \
-          > ./pytest-coverage.txt;
-        cat ./pytest-coverage.txt;
-    - name: Upload pytest coverage artifacts.
-      uses: actions/upload-artifact@v3
-      with:
-        name: pytest-coverage
-        path: ./pytest-coverage.txt
-    - name: Upload pytest junitxml artifacts.
-      uses: actions/upload-artifact@v3
-      with:
-        name: pytest-junitxml
-        path: pytest.xml
-    - name: Checking testing success.
-      if: steps.run-tests.outcome != 'success'
-      run: exit 1;
-
-  coverage:
-    runs-on: ubuntu-latest
-    needs: unit
-    if: success() || failure()
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-    - name: Get pytest artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: pytest-coverage
-    - name: Get pytest junitxml artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: pytest-junitxml
-    - name: Pytest coverage comment
-      if: github.event_name == 'pull_request'
-      uses: MishaKav/pytest-coverage-comment@main
-      with:
-        pytest-coverage-path: ./pytest-coverage.txt
-        junitxml-path: ./pytest.xml
+          --log-level=DEBUG \
+          --verbose
     - name: Upload coverage to Codecov
-      if: success() || failure()
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- Resolves #41

This pull request refactors the test workflow to handle failures gracefully. Previously, the workflow would continue even if tests failed, without reporting what the failures are. This PR resolves that by making the action fail upon test failure with full logging.

As a side-effect, coverage is no longer reported when tests fail. Having both accurate failures and coverage is a bit of a mess; to me this is an acceptable trade-off. 

